### PR TITLE
out_file: fix wrong assignment to ctx->template

### DIFF
--- a/plugins/out_file/file.c
+++ b/plugins/out_file/file.c
@@ -119,7 +119,6 @@ static int cb_file_init(struct flb_output_instance *ins,
         }
         else if (!strcasecmp(tmp, "template")) {
             ctx->format    = FLB_OUT_FILE_FMT_TEMPLATE;
-            ctx->template  = "{time} {message}";
         }
     }
 
@@ -458,7 +457,7 @@ static struct flb_config_map config_map[] = {
      NULL
     },
     {
-     FLB_CONFIG_MAP_STR, "template", NULL,
+     FLB_CONFIG_MAP_STR, "template", "{time} {message}",
      0, FLB_TRUE, offsetof(struct flb_file_conf, template),
      NULL
     },


### PR DESCRIPTION
The recent change introduced a bug that assigns the default value
after the configuration file is loaded. This resulted in out_file
ignoring the user settings.

Fix it by letting flb_output_config_map_set() handle default values,
not manually assigning them.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
